### PR TITLE
Fixed two Python3-related bugs

### DIFF
--- a/imagemounter/volume.py
+++ b/imagemounter/volume.py
@@ -516,7 +516,7 @@ class Volume(object):
                 logger.debug("Trying to determine fs type from '{}'".format(fsdesc))
                 if not fsdesc:
                     continue
-                fsdesc = fsdesc.lower()
+                fsdesc = str(fsdesc.lower())
 
                 # for the purposes of this function, logical volume is nothing, and 'primary' is rather useless info
                 if fsdesc in ('logical volume', 'luks volume', 'bde volume', 'raid volume',

--- a/imagemounter/volume_system.py
+++ b/imagemounter/volume_system.py
@@ -190,7 +190,7 @@ class VolumeSystem(object):
 
             try:
                 volumes = pytsk3.Volume_Info(baseimage, getattr(pytsk3, 'TSK_VS_TYPE_' + vstype.upper()),
-                                             int(self.parent.offset) / self.disk.block_size)
+                                             self.parent.offset // self.disk.block_size)
                 self.volume_source = 'multi'
                 return volumes
             except Exception as e:


### PR DESCRIPTION
The library was raising exceptions with Python 3, for two reasons:
1. integer division is not the default anymore
2. `bytes` and `str` are different now