### PR TITLE
add ADS support to mount command args

### DIFF
--- a/imagemounter/volume.py
+++ b/imagemounter/volume.py
@@ -663,7 +663,7 @@ class Volume(object):
                 call_mount('ufs', 'ufstype=ufs2,loop,offset=' + str(self.offset))
 
             elif fstype == 'ntfs':
-                call_mount('ntfs', 'show_sys_files,noexec,force,loop,offset=' + str(self.offset))
+                call_mount('ntfs', 'show_sys_files,noexec,force,loop,streams_interface=windows,offset=' + str(self.offset))
 
             elif fstype == 'xfs':
                 call_mount('xfs', 'norecovery,loop,offset=' + str(self.offset))


### PR DESCRIPTION
I needed support to access `$Extend/$UsnJrnl:$J `for forensic artifact extraction. 

From the ntfs-3g docs:
> By default, ntfs-3g will only read the unnamed data stream.
> By using the options "streams_interface=windows", with the ntfs-3g driver (not possible with lowntfs-3g), you will be able to read any named data streams, simply by specifying the stream's name after a colon. For example:
> 
> cat some.mp3:artist