### PR TITLE
add fusermount lazy unmount support

### DIFF
--- a/imagemounter/disk.py
+++ b/imagemounter/disk.py
@@ -11,7 +11,7 @@ import tempfile
 import time
 
 from imagemounter import _util, BLOCK_SIZE
-from imagemounter.exceptions import ImageMounterError, ArgumentError, MountpointEmptyError, MountError
+from imagemounter.exceptions import ImageMounterError, ArgumentError, MountpointEmptyError, MountError, SubsystemError
 from imagemounter.volume_system import VolumeSystem
 
 logger = logging.getLogger(__name__)
@@ -348,10 +348,16 @@ class Disk(object):
                 logger.warning("Error unmounting volume {0}".format(m.mountpoint))
 
         if self.mountpoint:
-            _util.clean_unmount(['fusermount', '-u'], self.mountpoint)
+            try:
+                _util.clean_unmount(['fusermount', '-u'], self.mountpoint)
+            except SubsystemError:
+                _util.clean_unmount(['fusermount', '-uz'], self.mountpoint)
 
         if self._paths.get('avfs'):
-            _util.clean_unmount(['fusermount', '-u'], self._paths['avfs'])
+            try:
+                _util.clean_unmount(['fusermount', '-u'], self._paths['avfs'])
+            except SubsystemError:
+                _util.clean_unmount(['fusermount', '-uz'], self._paths['avfs'])
 
         if self.rw_active() and remove_rw:
             os.remove(self.rwpath)

--- a/imagemounter/unmounter.py
+++ b/imagemounter/unmounter.py
@@ -5,6 +5,7 @@ import os
 import re
 import tempfile
 from imagemounter import _util
+from imagemounter.exceptions import SubsystemError
 
 
 class Unmounter(object):
@@ -195,7 +196,11 @@ class Unmounter(object):
         """Unmounts all mounts identified by :func:`find_base_images`"""
 
         for mountpoint in self.find_base_images():
-            _util.clean_unmount(['fusermount', '-u'], mountpoint)
+            try:
+                _util.clean_unmount(['fusermount', '-u'], mountpoint)
+            except SubsystemError:
+                _util.clean_unmount(['fusermount', '-uz'], mountpoint)
+
 
     def unmount_volume_groups(self):
         """Unmounts all volume groups and related loopback devices as identified by :func:`find_volume_groups`"""

--- a/imagemounter/volume.py
+++ b/imagemounter/volume.py
@@ -1124,7 +1124,10 @@ class Volume(object):
             del self._paths['luks']
 
         if self._paths.get('bde'):
-            _util.clean_unmount(['fusermount', '-u'], self._paths['bde'])
+            try:
+                _util.clean_unmount(['fusermount', '-u'], self._paths['bde'])
+            except SubsystemError:
+                _util.clean_unmount(['fusermount', '-uz'], self._paths['bde'])
             del self._paths['bde']
 
         if self._paths.get('md'):
@@ -1145,7 +1148,10 @@ class Volume(object):
                 raise SubsystemError(e)
 
         if self._paths.get('vss'):
-            _util.clean_unmount(['fusermount', '-u'], self._paths['vss'])
+            try:
+                _util.clean_unmount(['fusermount', '-u'], self._paths['vss'])
+            except SubsystemError:
+                _util.clean_unmount(['fusermount', '-uz'], self._paths['vss'])
             del self._paths['vss']
 
         if self.loopback:


### PR DESCRIPTION
At least in Ubuntu 14.04, when mounting and unmounting multiple images in succession fusermount can throw a system error which causes the disk to not unmount. Since these exceptions were passed in the existing code the disk would only partially unmount.  

Fusermount supports a lazy unmount flag just for this purpose `-z`. We still attempt to unmount the old way unless the exception is thrown.  

The lazy umount is provided by umount:
`Lazy unmount. Detach the filesystem from the filesystem hierarchy now, and cleanup all references to the filesystem as soon as it is not busy anymore.  (Requires kernel 2.4.11 or later.)`