### PR TITLE
Path expansion fix

### DIFF
--- a/imagemounter/_util.py
+++ b/imagemounter/_util.py
@@ -80,9 +80,9 @@ def expand_path(path):
     '/path/to/image.[0-9][0-9]?'
     """
     if is_encase(path):
-        return glob.glob(path[:-2] + '??')
+        return glob.glob(path[:-2] + '??') or [path]
     elif re.match(r'^.*\.\d{2,3}$', path):
-        return glob.glob(path[:path.rfind('.')] + '.[0-9][0-9]?')
+        return glob.glob(path[:path.rfind('.')] + '.[0-9][0-9]?') or [path]
     else:
         return [path]
 


### PR DESCRIPTION
_util.expand_path assumes image paths exist based on a derivation from the base path. This is not always the case, for example when an image ends with an IP-address.

Adjusted expand_path to return a list with the original path when glob.glob returns nothing.