### PR TITLE
Re-index loopback devices prior to unmount since previous umounts can…

### DIFF
--- a/imagemounter/unmounter.py
+++ b/imagemounter/unmounter.py
@@ -209,6 +209,9 @@ class Unmounter(object):
     def unmount_loopbacks(self):
         """Unmounts all loopback devices as identified by :func:`find_loopbacks`"""
 
+        # re-index loopback devices
+        self._index_loopbacks()
+
         for dev in self.find_loopbacks():
             _util.check_output_(['losetup', '-d', dev])
 


### PR DESCRIPTION
… remove devices causing the existing index to hold erroneous devices.

During testing I found that unmounting using the 'imount -u' command can fail to unmount and remove the /tmp/image_mounter_.... folder.  This was found to be due to the previous unmount_mounts() function removing the loopback device.  By re-indexing the loopback devices prior to attempting to unmount them in the unmount_loopbacks function, the unmounter class completes without error unmounting and removing the /tmp folder.