### PR TITLE
Updated _load_fsstat_data method to terminate at specified time.

### DIFF
--- a/imagemounter/volume.py
+++ b/imagemounter/volume.py
@@ -1025,16 +1025,16 @@ class Volume(object):
             logger.warning("fsstat is not installed, could not mount volume shadow copies")
             return
 
-        process = None
+        self.process = None
 
         def stats_thread():
             try:
                 cmd = ['fsstat', self.get_raw_path(), '-o', str(self.offset // self.disk.block_size)]
                 logger.debug('$ {0}'.format(' '.join(cmd)))
                 # noinspection PyShadowingNames
-                process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-                for line in iter(process.stdout.readline, b''):
+                for line in iter(self.process.stdout.readline, b''):
                     line = line.decode()
                     if line.startswith("File System Type:"):
                         self.info['statfstype'] = line[line.index(':') + 2:].strip()
@@ -1049,7 +1049,7 @@ class Volume(object):
                     elif 'CYLINDER GROUP INFORMATION' in line:
                         # noinspection PyBroadException
                         try:
-                            process.terminate()  # some attempt
+                            self.process.terminate()  # some attempt
                         except Exception:
                             pass
                         break
@@ -1077,7 +1077,7 @@ class Volume(object):
         if thread.is_alive():
             # noinspection PyBroadException
             try:
-                process.terminate()
+                self.process.terminate()
             except Exception:
                 pass
             thread.join()

--- a/imagemounter/volume.py
+++ b/imagemounter/volume.py
@@ -1049,7 +1049,7 @@ class Volume(object):
                     elif 'CYLINDER GROUP INFORMATION' in line:
                         # noinspection PyBroadException
                         try:
-                            self.process.terminate()  # some attempt
+                            process.terminate()  # some attempt
                         except Exception:
                             pass
                         break

--- a/imagemounter/volume.py
+++ b/imagemounter/volume.py
@@ -20,7 +20,6 @@ from imagemounter.exceptions import CommandNotFoundError, NoMountpointAvailableE
 from imagemounter.volume_system import VolumeSystem
 
 logger = logging.getLogger(__name__)
-process = None
 
 FILE_SYSTEM_GUIDS = {
     '2AE031AA-0F40-DB11-9590-000C2911D1B8': 'vmfs',


### PR DESCRIPTION
In my testing the fsstat subprocess was not being terminated after the allotted 5 seconds.

`1077    if thread.is_alive():`
`1078        # noinspection PyBroadException`
`1079        try:`
`1080        process.terminate()`

"process" at this point was type = <class 'NoneType'>

I added self. to the process references and the subprocess was then able to be terminated after 5 seconds.  After the change, self.process became type = <class 'subprocess.Popen'> as expected.

I haven't worked with threading so this may not be the proper way to fix this so feel free to suggest a more appropriate fix.  It appeared as though the scope of process was within the thread.
