### PR TITLE
Increase the allowed file extension length for segmented images. Resolves #22

### DIFF
--- a/imagemounter/_util.py
+++ b/imagemounter/_util.py
@@ -83,6 +83,8 @@ def expand_path(path):
         return glob.glob(path[:-2] + '??') or [path]
     elif re.match(r'^.*\.\d{2,3}$', path):
         return glob.glob(path[:path.rfind('.')] + '.[0-9][0-9]?') or [path]
+    elif re.match(r'^.*\.\d{4}$', path):
+        return glob.glob(path[:path.rfind('.')] + '.[0-9][0-9][0-9]?') or [path]
     else:
         return [path]
 

--- a/imagemounter/_util.py
+++ b/imagemounter/_util.py
@@ -81,10 +81,10 @@ def expand_path(path):
     """
     if is_encase(path):
         return glob.glob(path[:-2] + '??') or [path]
-    elif re.match(r'^.*\.\d{2,3}$', path):
-        return glob.glob(path[:path.rfind('.')] + '.[0-9][0-9]?') or [path]
-    elif re.match(r'^.*\.\d{4}$', path):
-        return glob.glob(path[:path.rfind('.')] + '.[0-9][0-9][0-9]?') or [path]
+    ext_match = re.match(r'^.*\.(\d{2,})$', path)
+    if ext_match is not None:
+        ext_size = len(ext_match.groups()[-1])
+        return glob.glob(path[:-ext_size] + '[0-9]' * ext_size) or [path]
     else:
         return [path]
 


### PR DESCRIPTION
This commit increases the allowed file extension length
for segmented images from 3 to 4 characters.

It should be noted that the file extensions should be of a
consistent length for a set of segmented file otherwise
the sorting internally in various mounting methods (eg xmount)
will not work correctly and the resultant image will be corrupt.

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>