### PR TITLE
GH-28: Refactor dependencies to allow programmatic access.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pip-delete-this-directory.txt
 .cache
 nosetests.xml
 coverage.xml
+.pytest_cache
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pip-delete-this-directory.txt
 nosetests.xml
 coverage.xml
 .pytest_cache
+htmlcov
 
 # Translations
 *.mo

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -1,0 +1,61 @@
+Dependencies
+============
+
+The ``imagemounter.dependencies`` module defines several optional and required
+dependencies to use ``imagemounter``. This data is used by the ``imount --check``
+command, and can also be accessed via Python code:
+
+.. code-block:: python
+
+    from imagemounter.dependencies import ewfmount
+
+    ...
+
+    if ewfmount.is_available:
+        do_something_with_ewfmount()
+    else:
+        print(ewfmount.printable_status)
+
+
+Full list of dependencies:
+
+- ``imagemounter.dependencies.affuse``
+- ``imagemounter.dependencies.bdemount``
+- ``imagemounter.dependencies.blkid``
+- ``imagemounter.dependencies.cryptsetup``
+- ``imagemounter.dependencies.disktype``
+- ``imagemounter.dependencies.ewfmount``
+- ``imagemounter.dependencies.file``
+- ``imagemounter.dependencies.fsstat``
+- ``imagemounter.dependencies.lvm``
+- ``imagemounter.dependencies.magic``
+- ``imagemounter.dependencies.mdadm``
+- ``imagemounter.dependencies.mmls``
+- ``imagemounter.dependencies.mount_jffs2``
+- ``imagemounter.dependencies.mount_ntfs``
+- ``imagemounter.dependencies.mount_squashfs``
+- ``imagemounter.dependencies.mount_xfs``
+- ``imagemounter.dependencies.mountavfs``
+- ``imagemounter.dependencies.parted``
+- ``imagemounter.dependencies.pytsk3``
+- ``imagemounter.dependencies.qemu_nbd``
+- ``imagemounter.dependencies.vmfs_fuse``
+- ``imagemounter.dependencies.vmware_mount``
+- ``imagemounter.dependencies.vshadowmount``
+- ``imagemounter.dependencies.xmount``
+
+API
+---
+
+The following classes are how dependencies are represented within imagemounter:
+
+.. autoclass:: Dependency
+    :members:
+.. autoclass:: CommandDependency
+    :members:
+.. autoclass:: PythonModuleDependency
+    :members:
+.. autoclass:: MagicDependency
+    :members:
+.. autoclass:: DependencySection
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Contents
    :maxdepth: 2
 
    installation
+   dependencies
    commandline
    python
    specifics

--- a/imagemounter/cli/__init__.py
+++ b/imagemounter/cli/__init__.py
@@ -11,7 +11,7 @@ class CheckAction(argparse.Action):
         print("The following commands are used by imagemounter internally. Without most commands, imagemounter "
               "works perfectly fine, but may lack some detection or mounting capabilities.")
 
-        for section in dependencies.ALL:
+        for section in dependencies.ALL_SECTIONS:
             section.print_status()
 
         parser.exit()

--- a/imagemounter/cli/__init__.py
+++ b/imagemounter/cli/__init__.py
@@ -12,7 +12,7 @@ class CheckAction(argparse.Action):
               "works perfectly fine, but may lack some detection or mounting capabilities.")
 
         for section in dependencies.ALL_SECTIONS:
-            section.print_status()
+            print(section.printable_status)
 
         parser.exit()
 

--- a/imagemounter/cli/__init__.py
+++ b/imagemounter/cli/__init__.py
@@ -1,74 +1,19 @@
 import argparse
 import logging
-from imagemounter import _util
+from imagemounter import _util, dependencies
 
 
 class CheckAction(argparse.Action):
     """Action that checks the current state of the system according to the command requirements that imount has."""
 
-    def _check_command(self, command, package="", why=""):
-        if _util.command_exists(command):
-            print(" INSTALLED {}".format(command))
-        elif why and package:
-            print(" MISSING   {:<20}needed for {}, part of the {} package".format(command, why, package))
-        elif why:
-            print(" MISSING   {:<20}needed for {}".format(command, why))
-        elif package:
-            print(" MISSING   {:<20}part of the {} package".format(command, package))
-        else:
-            print(" MISSING   {}".format(command))
-
-    def _check_module(self, module, pip_name="", why=""):
-        if not pip_name:
-            pip_name = module
-
-        if module == "magic" and _util.module_exists(module):
-            import magic
-            if hasattr(magic, 'from_file'):
-                print(" INSTALLED {:<20}(Python package)".format(pip_name))
-            elif hasattr(magic, 'open'):
-                print(" INSTALLED {:<20}(system package)".format(pip_name))
-            else:
-                print(" ERROR     {:<20}expecting {}, found other module named magic".format(pip_name, pip_name))
-        elif module != "magic" and _util.module_exists(module):
-            print(" INSTALLED {}".format(pip_name))
-        elif why:
-            print(" MISSING   {:<20}needed for {}, install using pip".format(pip_name, why))
-        else:
-            print(" MISSING   {:<20}install using pip".format(pip_name, why))
-
     # noinspection PyShadowingNames
     def __call__(self, parser, namespace, values, option_string=None):
         print("The following commands are used by imagemounter internally. Without most commands, imagemounter "
               "works perfectly fine, but may lack some detection or mounting capabilities.")
-        print("-- Mounting base disk images (at least one required, first three recommended) --")
-        self._check_command("xmount", "xmount", "several types of disk images")
-        self._check_command("ewfmount", "ewf-tools", "EWF images (partially covered by xmount)")
-        self._check_command("affuse", "afflib-tools", "AFF images (partially covered by xmount)")
-        self._check_command("vmware-mount", why="VMWare disks")
-        self._check_command("mountavfs", "avfs", "compressed disk images")
-        self._check_command("qemu-nbd", "qemu-utils", "Qcow2 images")
-        print("-- Detecting volumes and volume types (at least one required) --")
-        self._check_command("mmls", "sleuthkit")
-        self._check_module("pytsk3")
-        self._check_command("parted", "parted")
-        print("-- Detecting volume types (all recommended, first two highly recommended) --")
-        self._check_command("fsstat", "sleuthkit")
-        self._check_command("file", "libmagic1")
-        self._check_command("blkid")
-        self._check_module("magic", "python-magic")
-        self._check_command("disktype", "disktype")
-        print("-- Mounting volumes (install when needed) --")
-        self._check_command("mount.xfs", "xfsprogs", "XFS volumes")
-        self._check_command("mount.ntfs", "ntfs-3g", "NTFS volumes")
-        self._check_command("lvm", "lvm2", "LVM volumes")
-        self._check_command("vmfs-fuse", "vmfs-tools", "VMFS volumes")
-        self._check_command("mount.jffs2", "mtd-tools", "JFFS2 volumes")
-        self._check_command("mount.squashfs", "squashfs-tools", "SquashFS volumes")
-        self._check_command("mdadm", "mdadm", "RAID volumes")
-        self._check_command("cryptsetup", "cryptsetup", "LUKS containers")
-        self._check_command("bdemount", "libbde-utils", "Bitlocker Drive Encryption volumes")
-        self._check_command("vshadowmount", "libvshadow-utils", "NTFS volume shadow copies")
+
+        for section in dependencies.ALL:
+            section.print_status()
+
         parser.exit()
 
 

--- a/imagemounter/dependencies.py
+++ b/imagemounter/dependencies.py
@@ -11,7 +11,7 @@ class Dependency(object):
 
     @property
     def printable_status(self):
-        if self.check():
+        if self.is_available:
             return self.installed_explanation.format(self)
         else:
             return "MISSING   {!s:<20}".format(self) + self.missing_explanation
@@ -22,7 +22,8 @@ class CommandDependency(Dependency):
     def __str__(self):
         return self.name
 
-    def check(self):
+    @property
+    def is_available(self):
         """Check if the command is available on the system"""
         return _util.command_exists(self.name)
 
@@ -44,7 +45,8 @@ class PythonModuleDependency(Dependency):
         # Fall back to name if not provided (in case it's the same as the package)
         return self.package or self.name
 
-    def check(self):
+    @property
+    def is_available(self):
         """Check if the Python module is available"""
         return _util.module_exists(self.name)
 
@@ -63,7 +65,8 @@ class MagicDependency(PythonModuleDependency):
         super(MagicDependency, self).__init__("magic", "python-magic")
         self.source = None
 
-    def check(self):
+    @property
+    def is_available(self):
         try:
             import magic
         except ImportError:

--- a/imagemounter/dependencies.py
+++ b/imagemounter/dependencies.py
@@ -1,0 +1,153 @@
+from imagemounter import _util
+
+
+class Dependency(object):
+    installed_explanation = "INSTALLED {!s}"
+
+    def __init__(self, name, package="", why=""):
+        self.name = name
+        self.package = package
+        self.why = why
+
+    @property
+    def status(self):
+        if self.check():
+            return self.installed_explanation.format(self)
+        else:
+            return "MISSING   {!s:<20}".format(self) + self.missing_explanation
+
+
+class CommandDependency(Dependency):
+
+    def __str__(self):
+        return self.name
+
+    def check(self):
+        """Check if the command is available on the system"""
+        return _util.command_exists(self.name)
+
+    @property
+    def missing_explanation(self):
+        if self.why and self.package:
+            return "needed for {}, part of the {} package".format(self.why, self.package)
+        elif self.why:
+            return "needed for {}".format(self.why)
+        elif self.package:
+            return "part of the {} package".format(self.package)
+        else:
+            return ""
+
+
+class PyModuleDependency(Dependency):
+
+    def __str__(self):
+        # Fall back to name if not provided (in case it's the same as the package)
+        return self.package or self.name
+
+    def check(self):
+        """Check if the Python module is available"""
+        return _util.module_exists(self.name)
+
+    @property
+    def missing_explanation(self):
+        if self.why:
+            return "needed for {}, install using pip".format(self.why)
+        else:
+            return "install using pip"
+
+
+class MagicDependency(PyModuleDependency):
+    """This is a special case"""
+
+    def __init__(self):
+        super(MagicDependency, self).__init__("magic", "python-magic")
+        self.source = None
+
+    def check(self):
+        try:
+            import magic
+        except ImportError:
+            return False
+
+        if hasattr(magic, 'from_file'):
+            self.source = "Python package"
+        elif hasattr(magic, 'open'):
+            self.source = "system package"
+        else:
+            self.source = "unknown"
+
+        return True
+
+    @property
+    def installed_explanation(self):
+        if not self.source:
+            self.check()
+        if self.source == "unknown":
+            return "ERROR     {0!s:<20}expecting {0}, found other module named {0.name}"
+        return "INSTALLED {!s:<20}" + "({})".format(self.source)
+
+
+class DependencySection(object):
+
+    def __init__(self, name, description, deps):
+        self.name = name
+        self.description = description
+        self.deps = deps
+
+    def print_status(self):
+        print("-- {0.name} ({0.description}) --".format(self))
+        for dep in self.deps:
+            print(" " + dep.status)
+
+
+xmount = CommandDependency("xmount", "xmount", "several types of disk images")
+ewfmount = CommandDependency("ewfmount", "ewf-tools", "EWF images (partially covered by xmount)")
+affuse = CommandDependency("affuse", "afflib-tools", "AFF images (partially covered by xmount)")
+vmware_mount = CommandDependency("vmware-mount", why="VMWare disks")
+mountavfs = CommandDependency("mountavfs", "avfs", "compressed disk images")
+qemu_nbd = CommandDependency("qemu-nbd", "qemu-utils", "Qcow2 images")
+
+mmls = CommandDependency("mmls", "sleuthkit")
+pytsk3 = PyModuleDependency("pytsk3")
+parted = CommandDependency("parted", "parted")
+
+fsstat = CommandDependency("fsstat", "sleuthkit")
+file = CommandDependency("file", "libmagic1")
+blkid = CommandDependency("blkid")
+magic = MagicDependency()
+disktype = CommandDependency("disktype", "disktype")
+
+mount_xfs = CommandDependency("mount.xfs", "xfsprogs", "XFS volumes")
+mount_ntfs = CommandDependency("mount.ntfs", "ntfs-3g", "NTFS volumes")
+lvm = CommandDependency("lvm", "lvm2", "LVM volumes")
+vmfs_fuse = CommandDependency("vmfs-fuse", "vmfs-tools", "VMFS volumes")
+mount_jffs2 = CommandDependency("mount.jffs2", "mtd-tools", "JFFS2 volumes")
+mount_squashfs = CommandDependency("mount.squashfs", "squashfs-tools", "SquashFS volumes")
+mdadm = CommandDependency("mdadm", "mdadm", "RAID volumes")
+cryptsetup = CommandDependency("cryptsetup", "cryptsetup", "LUKS containers")
+bdemount = CommandDependency("bdemount", "libbde-utils", "Bitlocker Drive Encryption volumes")
+vshadowmount = CommandDependency("vshadowmount", "libvshadow-utils", "NTFS volume shadow copies")
+
+mount_images = DependencySection(name="Mounting base disk images",
+                                 description="at least one required, first three recommended",
+                                 deps=[xmount, ewfmount, affuse, vmware_mount, mountavfs, qemu_nbd])
+
+detect_volumes = DependencySection(name="Detecting volumes and volume types",
+                                   description="at least one required",
+                                   deps=[mmls, pytsk3, parted])
+
+detect_volume_types = DependencySection(name="Detecting volume types",
+                                        description="all recommended, first two highly recommended",
+                                        deps=[fsstat, file, blkid, magic, disktype])
+
+mount_volumes = DependencySection(name="Mounting volumes",
+                                  description="install when needed",
+                                  deps=[mount_xfs, mount_ntfs, lvm, vmfs_fuse, mount_jffs2,
+                                        mount_squashfs, mdadm, cryptsetup, bdemount, vshadowmount])
+
+ALL = [
+    mount_images,
+    detect_volumes,
+    detect_volume_types,
+    mount_volumes,
+]

--- a/imagemounter/dependencies.py
+++ b/imagemounter/dependencies.py
@@ -38,7 +38,7 @@ class CommandDependency(Dependency):
             return ""
 
 
-class PyModuleDependency(Dependency):
+class PythonModuleDependency(Dependency):
 
     def __str__(self):
         # Fall back to name if not provided (in case it's the same as the package)
@@ -56,7 +56,7 @@ class PyModuleDependency(Dependency):
             return "install using pip"
 
 
-class MagicDependency(PyModuleDependency):
+class MagicDependency(PythonModuleDependency):
     """This is a special case"""
 
     def __init__(self):
@@ -108,7 +108,7 @@ mountavfs = CommandDependency("mountavfs", "avfs", "compressed disk images")
 qemu_nbd = CommandDependency("qemu-nbd", "qemu-utils", "Qcow2 images")
 
 mmls = CommandDependency("mmls", "sleuthkit")
-pytsk3 = PyModuleDependency("pytsk3")
+pytsk3 = PythonModuleDependency("pytsk3")
 parted = CommandDependency("parted", "parted")
 
 fsstat = CommandDependency("fsstat", "sleuthkit")
@@ -145,7 +145,7 @@ mount_volumes = DependencySection(name="Mounting volumes",
                                   deps=[mount_xfs, mount_ntfs, lvm, vmfs_fuse, mount_jffs2,
                                         mount_squashfs, mdadm, cryptsetup, bdemount, vshadowmount])
 
-ALL = [
+ALL_SECTIONS = [
     mount_images,
     detect_volumes,
     detect_volume_types,

--- a/imagemounter/dependencies.py
+++ b/imagemounter/dependencies.py
@@ -10,7 +10,7 @@ class Dependency(object):
         self.why = why
 
     @property
-    def status(self):
+    def printable_status(self):
         if self.check():
             return self.installed_explanation.format(self)
         else:
@@ -94,10 +94,14 @@ class DependencySection(object):
         self.description = description
         self.deps = deps
 
-    def print_status(self):
-        print("-- {0.name} ({0.description}) --".format(self))
+    @property
+    def printable_status(self):
+        lines = [
+            "-- {0.name} ({0.description}) --".format(self)
+        ]
         for dep in self.deps:
-            print(" " + dep.status)
+            lines.append(" " + dep.printable_status)
+        return "\n".join(lines)
 
 
 xmount = CommandDependency("xmount", "xmount", "several types of disk images")

--- a/tests/dependencies_test.py
+++ b/tests/dependencies_test.py
@@ -1,0 +1,171 @@
+import mock
+import os
+import subprocess
+import sys
+import unittest
+
+from imagemounter.dependencies import (CommandDependency, Dependency,
+        DependencySection, MagicDependency, PythonModuleDependency)
+
+
+class DependencyTest(unittest.TestCase):
+
+    @unittest.skip("depends on previous output of imount --check")
+    def test_imount_check_output(self):
+        # This test can be used to verify that the output of ``imount --check``
+        # hasn't changed. To use this, first run:
+        #    imount --check > ~/imount-check-results.txt
+        # Then make any code changes and run this test (remove @unittest.skip).
+        self.maxDiff = None
+        expected = open(os.path.expanduser("~/imount-check-results.txt")).read()
+        actual = subprocess.check_output(['imount', '--check']).decode("utf-8")
+
+        self.assertEqual(expected, actual)
+
+
+class CommandDependencyTest(unittest.TestCase):
+
+    def test_existing_dependency(self):
+        dep = CommandDependency('ls')
+        self.assertTrue(dep.is_available)
+
+    def test_missing_dependency(self):
+        dep = CommandDependency('lsxxxx')
+        self.assertFalse(dep.is_available)
+
+    @mock.patch('imagemounter.dependencies._util')
+    def test_mocked_dependency(self, util):
+        util.command_exists.return_value = True
+        dep = CommandDependency('lsxxxx')
+        self.assertTrue(dep.is_available)
+        self.assertEqual(dep.printable_status, "INSTALLED lsxxxx")
+
+    @mock.patch('imagemounter.dependencies._util')
+    def test_dependency_status_message(self, util):
+        util.command_exists.return_value = False
+        dep = CommandDependency('ls')
+        self.assertFalse(dep.is_available)
+        self.assertEqual(dep.printable_status.strip(), "MISSING   ls")
+
+    @mock.patch('imagemounter.dependencies._util')
+    def test_dependency_status_message_package(self, util):
+        util.command_exists.return_value = False
+        dep = CommandDependency('ls', package="core-utils")
+        self.assertFalse(dep.is_available)
+        expected = "MISSING   ls                  part of the core-utils package"
+        self.assertEqual(dep.printable_status.strip(), expected)
+
+    @mock.patch('imagemounter.dependencies._util')
+    def test_dependency_status_message_why(self, util):
+        util.command_exists.return_value = False
+        dep = CommandDependency('ls', why="listing files")
+        self.assertFalse(dep.is_available)
+        expected = "MISSING   ls                  needed for listing files"
+        self.assertEqual(dep.printable_status.strip(), expected)
+
+    @mock.patch('imagemounter.dependencies._util')
+    def test_dependency_status_message_package_why(self, util):
+        util.command_exists.return_value = False
+        dep = CommandDependency('ls', package="core-utils", why="listing files")
+        self.assertFalse(dep.is_available)
+        expected = "MISSING   ls                  needed for listing files, part of the core-utils package"
+        self.assertEqual(dep.printable_status.strip(), expected)
+
+
+class PythonModuleDependencyTest(unittest.TestCase):
+
+    def test_existing_dependency(self):
+        dep = PythonModuleDependency('sys')
+        self.assertTrue(dep.is_available)
+
+    def test_missing_dependency(self):
+        dep = PythonModuleDependency('foobarnonexistent')
+        self.assertFalse(dep.is_available)
+
+    @mock.patch('imagemounter.dependencies._util')
+    def test_mocked_dependency(self, util):
+        util.module_exists.return_value = True
+        dep = PythonModuleDependency('requests2')
+        self.assertTrue(dep.is_available)
+        self.assertEqual(dep.printable_status, "INSTALLED requests2")
+
+    @mock.patch('imagemounter.dependencies._util')
+    def test_mocked_status_message(self, util):
+        util.module_exists.return_value = False
+        dep = PythonModuleDependency('sys')
+        self.assertFalse(dep.is_available)
+        expected = "MISSING   sys                 install using pip"
+        self.assertEqual(dep.printable_status, expected)
+
+    @mock.patch('imagemounter.dependencies._util')
+    def test_mocked_status_message_why(self, util):
+        util.module_exists.return_value = False
+        dep = PythonModuleDependency('sys', why="system functions")
+        self.assertFalse(dep.is_available)
+        expected = "MISSING   sys                 needed for system functions, install using pip"
+        self.assertEqual(dep.printable_status, expected)
+
+
+class MagicDependencyTest(unittest.TestCase):
+
+    def setUp(self):
+        self.magic = MagicDependency("python-magic")
+
+    def tearDown(self):
+        # After each test, remove the fake "magic" module we've created.
+        if 'magic' in sys.modules:
+            del sys.modules['magic']
+
+    @mock.patch('imagemounter.dependencies._util')
+    def test_not_exists(self, util):
+        util.module_exists.return_value = False
+        self.assertFalse(self.magic.is_available)
+        self.assertFalse(self.magic._importable)
+        expected = "MISSING   python-magic        install using pip"
+        self.assertEqual(self.magic.printable_status, expected)
+
+    def test_exists_pypi(self):
+        sys.modules['magic'] = mock.Mock(['from_file'])
+        self.assertTrue(self.magic.is_available)
+        self.assertTrue(self.magic.is_python_package)
+        self.assertFalse(self.magic.is_system_package)
+        expected = "INSTALLED python-magic        (Python package)"
+        self.assertEqual(self.magic.printable_status, expected)
+
+    def test_exists_system(self):
+        sys.modules['magic'] = mock.Mock(['open'])
+        self.assertTrue(self.magic.is_available)
+        self.assertFalse(self.magic.is_python_package)
+        self.assertTrue(self.magic.is_system_package)
+        expected = "INSTALLED python-magic        (system package)"
+        self.assertEqual(self.magic.printable_status, expected)
+
+    def test_exists_unknown(self):
+        sys.modules['magic'] = mock.Mock([])
+        self.assertTrue(self.magic._importable)
+        self.assertFalse(self.magic.is_available)
+        self.assertFalse(self.magic.is_python_package)
+        self.assertFalse(self.magic.is_system_package)
+        expected = "ERROR     python-magic        expecting python-magic, found other module named magic"
+        self.assertEqual(self.magic.printable_status, expected)
+
+
+class DependencySectionTest(unittest.TestCase):
+
+    def test_section_no_deps(self):
+        section = DependencySection(name="empty section",
+                                    description='not needed',
+                                    deps=[])
+
+        expected = "-- empty section (not needed) --"
+        self.assertEqual(expected, section.printable_status)
+
+    def test_section_printable_status(self):
+        mock_dependency = mock.Mock()
+        mock_dependency.printable_status = "I'm just a mock"
+        section = DependencySection(name="fake section",
+                                    description='needed for stuff',
+                                    deps=[mock_dependency])
+
+        expected = "-- fake section (needed for stuff) --\n I'm just a mock"
+        self.assertEqual(expected, section.printable_status)


### PR DESCRIPTION
- Create classes for CommandDependency, PyModuleDependency.
- Add special class for handling "magic" dependency.
- Add DependencySection class for grouping dependencies.
- Simplify CheckAction to use these new classes

Output of `imount --check` should be identical to before.