### PR TITLE
dd replaced with raw

### DIFF
--- a/imagemounter/disk.py
+++ b/imagemounter/disk.py
@@ -179,7 +179,7 @@ class Disk(object):
                 cmds.append(['xmount', ])
                 if self.read_write:
                     cmds[-1].extend(['--cache', self.rwpath])
-                cmds[-1].extend(['--in', 'ewf' if disk_type == 'encase' else 'dd'])
+                cmds[-1].extend(['--in', 'ewf' if disk_type == 'encase' else 'raw'])
                 cmds[-1].extend(self.paths)  # specify all paths, xmount needs this :(
                 cmds[-1].append(self.mountpoint)
 


### PR DESCRIPTION
`dd `option for `xmount --in` is  is deprecated in latest xmount, replaced with `raw`. It causing error when mounting readwrite mode.